### PR TITLE
Mandated a minimum fuzziness of 1

### DIFF
--- a/HousingRegisterApi/V1/Infrastructure/Search/ApplicationSearchSemiStructuredQuery.cs
+++ b/HousingRegisterApi/V1/Infrastructure/Search/ApplicationSearchSemiStructuredQuery.cs
@@ -71,7 +71,7 @@ namespace HousingRegisterApi.V1.Infrastructure.Search
                 }
                 else
                 {
-                    termFuzziness = Math.Min(term.Length / 4, maxFuzinessPerTerm);
+                    termFuzziness = Math.Max(1, Math.Min(term.Length / 4, maxFuzinessPerTerm));
 
                     output.Append($" {term}~{termFuzziness}");
                 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/HRT-521

## Describe this PR

### *What is the problem we're trying to solve*

Fuzzy matching was not being applied to short terms (>4)

### *What changes have we introduced*

Applied a minimum fuzzy value of 1, independent of term size.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*
N/A
