### PR TITLE
TF changes for SSO

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -51,7 +51,7 @@ resource "aws_ssm_parameter" "housingregister_sns_arn" {
 }
 
 module "housingregister_api_cloudwatch_dashboard" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
   environment_name    = var.environment_name
   api_name            = "housing-register-api"
   sns_topic_name      = aws_sns_topic.housingregister_topic.name

--- a/terraform/development/searchDomain.tf
+++ b/terraform/development/searchDomain.tf
@@ -13,7 +13,7 @@ data "aws_subnet_ids" "development" {
 }
 
 module "elasticsearch_db_development" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
   vpc_id              = data.aws_vpc.development_vpc.id
   environment_name    = var.environment_name
   port                = 443

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -51,7 +51,7 @@ resource "aws_ssm_parameter" "housingregister_sns_arn" {
 }
 
 module "housingregister_api_cloudwatch_dashboard" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
   environment_name    = var.environment_name
   api_name            = "housing-register-api"
   sns_topic_name      = aws_sns_topic.housingregister_topic.name

--- a/terraform/production/searchDomain.tf
+++ b/terraform/production/searchDomain.tf
@@ -13,7 +13,7 @@ data "aws_subnet_ids" "production" {
 }
 
 module "elasticsearch_db_production" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
   vpc_id              = data.aws_vpc.production_vpc.id
   environment_name    = var.environment_name
   port                = 443

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -51,7 +51,7 @@ resource "aws_ssm_parameter" "housingregister_sns_arn" {
 }
 
 module "housingregister_api_cloudwatch_dashboard" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/dashboards/api-dashboard"
   environment_name    = var.environment_name
   api_name            = "housing-register-api"
   sns_topic_name      = aws_sns_topic.housingregister_topic.name

--- a/terraform/staging/searchDomain.tf
+++ b/terraform/staging/searchDomain.tf
@@ -13,7 +13,7 @@ data "aws_subnet_ids" "staging" {
 }
 
 module "elasticsearch_db_staging" {
-  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
+  source              = "git::git@github.com:LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
   vpc_id              = data.aws_vpc.staging_vpc.id
   environment_name    = var.environment_name
   port                = 443


### PR DESCRIPTION
When trying to merge the .NET upgrades into development, there was a pipeline error when Terraform tried to get the modules, as now we use SSO
The changes in this PR mean that TF will hopefully access those resources via SSH as opposed to HTTP
(This change was suggested by @spikeheap 🙏 )