### PR TITLE
TS-1986 separate terraform and code deployment workflows for development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,9 @@ workflows:
           context: api-nuget-token-context
       - build-and-test:
           context: api-nuget-token-context
-      - assume-role-development-for-code-deployment:
+      - assume-role-development:
           context: api-assume-role-housing-development-context
+          name: assume-role-development-for-code-deployment
           requires:
             - build-and-test
           filters:
@@ -227,8 +228,9 @@ workflows:
             filters:
               branches:
                 only: development
-      - assume-role-development-for-terraform-deployment:
+      - assume-role-development:
           context: api-assume-role-housing-development-context
+          name: assume-role-development-for-terraform-deployment
           requires:
             - permit-development-terraform-workflow
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ workflows:
           context: api-nuget-token-context
       - build-and-test:
           context: api-nuget-token-context
-      - assume-role-development:
+      - assume-role-development-for-code-deployment:
           context: api-assume-role-housing-development-context
           requires:
             - build-and-test
@@ -218,7 +218,7 @@ workflows:
             - api-nuget-token-context
             - "Serverless Framework"  
           requires:
-            - assume-role-development
+            - assume-role-development-for-code-deployment
           filters:
             branches:
               only: development
@@ -227,7 +227,7 @@ workflows:
             filters:
               branches:
                 only: development
-      - assume-role-development:
+      - assume-role-development-for-terraform-deployment:
           context: api-assume-role-housing-development-context
           requires:
             - permit-development-terraform-workflow
@@ -236,7 +236,7 @@ workflows:
               only: development
       - terraform-init-and-plan-development:
           requires:
-            - assume-role-development
+            - assume-role-development-for-terraform-deployment
           filters:
             branches:
               only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,32 +213,43 @@ workflows:
           filters:
             branches:
               only: development
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"  
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              only: development
+      - permit-development-terraform-workflow:
+            type: approval
+            filters:
+              branches:
+                only: development
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - permit-development-terraform-workflow
+          filters:
+            branches:
+              only: development
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
           filters:
             branches:
               only: development
-      #Enable this to check the plan before applying changes. Also please remember to change the required dependency below
-      # - permit-development-terraform-release:
-      #     type: approval
-      #     requires:
-      #       - terraform-init-and-plan-development
-      #     filters:
-      #       branches:
-      #         only: development
-      - terraform-apply-development:
+      - permit-development-terraform-release:
+          type: approval
           requires:
             - terraform-init-and-plan-development
           filters:
             branches:
               only: development
-      - deploy-to-development:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"  
+      - terraform-apply-development:
           requires:
-            - terraform-apply-development
+            - permit-development-terraform-release
           filters:
             branches:
               only: development


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1986](https://hackney.atlassian.net/browse/TS-1986)

## Describe this PR

### *What is the problem we're trying to solve*

Running Terraform deployment at the same time with code deployments is problematic in many ways. Typically we don't have to or want to run any Terraform changes when deploying code changes. Sometimes there are dependencies to infrastructure in the code, but there are better ways to manage that.

### *What changes have we introduced*

This update separates the code and Terraform deployment workflows, so that Terraform workflow only starts when approved. This way code changes can be deployed automatically as before without having to worry about Terraform changes at the same time. This update only includes the development branch workflow. Staging and production will be updated in separate PRs.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.


[TS-1986]: https://hackney.atlassian.net/browse/TS-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ