### PR TITLE
TS-1986 Separate terraform from code deployment workflow for stg and prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,28 +265,9 @@ workflows:
               only: master
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
+          name: assume-role-staging-for-code-deployment
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: master
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      #Enable this to check the plan before applying changes. Also please remember to change the required dependency below
-      #     - permit-staging-terraform-release:
-      # type: approval
-      # requires:
-      #   - terraform-init-and-plan-staging
-      # filters:
-      #   branches:
-      #     only: master
-      - terraform-apply-staging:
-          requires:
-            - terraform-init-and-plan-staging
           filters:
             branches:
               only: master
@@ -295,23 +276,85 @@ workflows:
             - api-nuget-token-context
             - "Serverless Framework"         
           requires:
-            - terraform-apply-staging
+            - assume-role-staging-for-code-deployment
           filters:
             branches:
               only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
+          name: assume-role-production-for-code-deployment
           requires:
             - deploy-to-staging
           filters:
             branches:
               only: master
-      - terraform-init-and-plan-production:
+      - permit-production-release:
+          type: approval
           requires:
-            - assume-role-production
+            - assume-role-production-for-code-deployment
           filters:
             branches:
-              only: master     
+              only: master
+      - deploy-to-production:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"  
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: master
+      - permit-staging-and-production-terraform-workflow:
+            type: approval
+            filters:
+              branches:
+                only: master
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          name: assume-role-staging-for-terraform-deployment
+          requires:
+            - permit-staging-and-production-terraform-workflow
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging-for-terraform-deployment
+          filters:
+            branches:
+              only: master
+      - permit-staging-terraform-release:
+          type: approval
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: master
+      - terraform-apply-staging:
+          requires:
+            - permit-staging-terraform-release
+          filters:
+            branches:
+              only: master
+      - permit-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          name: assume-role-production-for-terraform-deployment
+          requires:
+            - permit-production-terraform-workflow
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production-for-terraform-deployment
+          filters:
+            branches:
+              only: master  
       - permit-production-terraform-release:
           type: approval
           requires:
@@ -322,24 +365,6 @@ workflows:
       - terraform-apply-production:
           requires:
             -  permit-production-terraform-release
-          filters:
-            branches:
-              only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-            - terraform-apply-production
-          filters:
-            branches:
-              only: master
-      - deploy-to-production:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"  
-          requires:
-            - permit-production-release
-            - terraform-apply-production
           filters:
             branches:
               only: master


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1986](https://hackney.atlassian.net/browse/TS-1986)

## Describe this PR

### *What is the problem we're trying to solve*

Same as https://github.com/LBHackney-IT/lbh-housing-api/pull/244, but for staging and production.

### *What changes have we introduced*

Separate terraform from code deployment workflow, so it runs in parallel and only after approval. This will allow us to deploy code changes without having to deploy infrastructure changes at the same time.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1986]: https://hackney.atlassian.net/browse/TS-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ