### PR TITLE
Add production workflow approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,10 +247,17 @@ workflows:
           filters:
             branches:
               only: master
+      - permit-production-workflow:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:
-            - deploy-to-staging
+            - permit-production-workflow
           filters:
             branches:
               only: master


### PR DESCRIPTION
Add approval step before running the production deploymet workflow to ensure production role is not assumed unnecessarily and too early.