### PR TITLE
Increase dynamodb read capacity

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 10
   minCapacity = 2
-  maxCapacity = 50
+  maxCapacity = 55
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 10
   minCapacity = 2
-  maxCapacity = 50
+  maxCapacity = 100
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 50
   minCapacity = 2
-  maxCapacity = 50
+  maxCapacity = 55
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",


### PR DESCRIPTION
Halo ID: 222491

Report generator feature has started failing due to DynamoDB exceeding its read capacity. The operation is failing with a message "Amazon.DynamoDBv2.AmazonDynamoDBException: The level of configured provisioned throughput for the table was exceeded".

This update increases the capacity for all environments. Production capacity is based on the logs for the failed runs and 100 should be sufficient upgrade for now. Other environments have been updated just so we can test the update first.