### PR TITLE
Tweak max capacity

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 10
   minCapacity = 2
-  maxCapacity = 55
+  maxCapacity = 50
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 10
   minCapacity = 2
-  maxCapacity = 100
+  maxCapacity = 50
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",
@@ -110,7 +110,7 @@ resource "aws_dynamodb_table" "housingregisterapi_dynamodb_table" {
 }
 
 resource "aws_appautoscaling_target" "housingregisterapi_dynamodb_table_read_target" {
-  max_capacity       = local.maxCapacity
+  max_capacity       = 100 #To enable report generation with increased record count
   min_capacity       = 10  #Temporary set run applicant feed
   resource_id        = "table/HousingRegister"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -1,7 +1,7 @@
 locals {
   defaultCapacity = 50
   minCapacity = 2
-  maxCapacity = 55
+  maxCapacity = 50
   indexNames = toset([
     "table/HousingRegister/index/HousingRegisterAll",
     "table/HousingRegister/index/HousingRegisterStatus",

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -110,7 +110,7 @@ resource "aws_dynamodb_table" "housingregisterapi_dynamodb_table" {
 }
 
 resource "aws_appautoscaling_target" "housingregisterapi_dynamodb_table_read_target" {
-  max_capacity       = local.maxCapacity
+  max_capacity       = 55
   min_capacity       = local.minCapacity
   resource_id        = "table/HousingRegister"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"


### PR DESCRIPTION
Revert the default max capacity to 50 for all environments and only increase the max read capacity on prod which is causing issues at the moment. Staging change is just for testing.