### PR TITLE
Increase read capacity

### DIFF
--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -110,7 +110,7 @@ resource "aws_dynamodb_table" "housingregisterapi_dynamodb_table" {
 }
 
 resource "aws_appautoscaling_target" "housingregisterapi_dynamodb_table_read_target" {
-  max_capacity       = 100 #To enable report generation with increased record count
+  max_capacity       = 200 #To enable report generation with increased record count
   min_capacity       = 10  #Temporary set run applicant feed
   resource_id        = "table/HousingRegister"
   scalable_dimension = "dynamodb:table:ReadCapacityUnits"


### PR DESCRIPTION
Increase max read capacity to 200. Current demand seems to peak at 135, so this gives some headroom.