### PR TITLE
Bump JWT core to 1.87.0 for Cognito token support

### DIFF
--- a/HousingRegisterApi/HousingRegisterApi.csproj
+++ b/HousingRegisterApi/HousingRegisterApi.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
         <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0" />
         <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
-        <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+        <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
         <PackageReference Include="dotenv.net" Version="3.1.0" />
         <PackageReference Include="GovukNotify" Version="4.0.1" />
         <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.49 -> ... -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence. The only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.