### PR TITLE
Ssi 1162 hr auth

### DIFF
--- a/HousingRegisterApi.Tests/V1/Infrastructure/BlockedAuthEmailMatcherTests.cs
+++ b/HousingRegisterApi.Tests/V1/Infrastructure/BlockedAuthEmailMatcherTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using HousingRegisterApi.V1.Infrastructure;
+using NUnit.Framework;
+
+namespace HousingRegisterApi.Tests.V1.Infrastructure
+{
+    public class BlockedAuthEmailMatcherTests
+    {
+        [TestCase("scanner@prbly.win", "scanner@prbly.win", true)]
+        [TestCase("SCANNER@prbly.win", "scanner@prbly.win", true)]
+        [TestCase("scanner@prbly.win", "*@prbly.win", true)]
+        [TestCase("other@prbly.win", "*@prbly.win", true)]
+        [TestCase("resident@hackney.gov.uk", "scanner@prbly.win,*@prbly.win", false)]
+        [TestCase("resident@hackney.gov.uk", "", false)]
+        [TestCase("resident@hackney.gov.uk", null, false)]
+        public void IsBlockedMatchesConfiguredRules(
+            string email,
+            string blockedEmailsConfig,
+            bool expected)
+        {
+            BlockedAuthEmailMatcher.IsBlocked(email, blockedEmailsConfig)
+                .Should()
+                .Be(expected);
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
@@ -1,5 +1,6 @@
 using AutoFixture;
 using FluentAssertions;
+using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
 using HousingRegisterApi.V1.Domain;
@@ -16,6 +17,7 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         private Mock<IApplicationApiGateway> _mockApplicationGateway;
         private Mock<INotifyGateway> _mockNotifyGateway;
         private Mock<IActivityGateway> _mockActivityGateway;
+        private ApiOptions _apiOptions;
         private CreateAuthUseCase _classUnderTest;
         private Fixture _fixture;
 
@@ -25,7 +27,12 @@ namespace HousingRegisterApi.Tests.V1.UseCase
             _mockApplicationGateway = new Mock<IApplicationApiGateway>();
             _mockNotifyGateway = new Mock<INotifyGateway>();
             _mockActivityGateway = new Mock<IActivityGateway>();
-            _classUnderTest = new CreateAuthUseCase(_mockApplicationGateway.Object, _mockNotifyGateway.Object, _mockActivityGateway.Object);
+            _apiOptions = new ApiOptions();
+            _classUnderTest = new CreateAuthUseCase(
+                _mockApplicationGateway.Object,
+                _mockNotifyGateway.Object,
+                _mockActivityGateway.Object,
+                _apiOptions);
             _fixture = new Fixture();
         }
 
@@ -75,6 +82,28 @@ namespace HousingRegisterApi.Tests.V1.UseCase
             // Assert
             _mockApplicationGateway.Verify(x => x.CreateVerifyCode(It.IsAny<Guid>(), It.IsAny<CreateAuthRequest>()));
             response.Should().BeOfType<CreateAuthResponse>();
+        }
+
+        [Test]
+        public void CreateVerifyCodeThrowsWhenEmailIsBlocked()
+        {
+            _apiOptions.BlockedAuthEmails = "scanner@prbly.win,*@prbly.win";
+
+            Action act = () => _classUnderTest.Execute(new CreateAuthRequest
+            {
+                Email = "scanner@prbly.win"
+            });
+
+            act.Should().Throw<AuthGenerateBlockedException>();
+            _mockApplicationGateway.Verify(
+                x => x.GetIncompleteApplication(It.IsAny<string>()),
+                Times.Never);
+            _mockApplicationGateway.Verify(
+                x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()),
+                Times.Never);
+            _mockNotifyGateway.Verify(
+                x => x.SendVerifyCode(It.IsAny<Applicant>(), It.IsAny<string>()),
+                Times.Never);
         }
     }
 }

--- a/HousingRegisterApi/V1/ApiOptions.cs
+++ b/HousingRegisterApi/V1/ApiOptions.cs
@@ -13,6 +13,12 @@ namespace HousingRegisterApi.V1
         public string EvidenceApiPostClaimsToken { get; set; }
         public Uri ActivityHistoryApiUrl { get; set; }
 
+        /// <summary>
+        /// Comma-separated auth email blocklist. Supports exact emails and domain
+        /// wildcards such as *@prbly.win.
+        /// </summary>
+        public string BlockedAuthEmails { get; set; }
+
         public static ApiOptions FromEnv()
         {
             var evidenceApiUrl = Environment.GetEnvironmentVariable("EVIDENCE_API_URL");
@@ -28,6 +34,7 @@ namespace HousingRegisterApi.V1
                 EvidenceApiGetClaimsToken = Environment.GetEnvironmentVariable("EVIDENCE_API_GET_EVIDENCE_REQUESTS_TOKEN"),
                 EvidenceApiPostClaimsToken = Environment.GetEnvironmentVariable("EVIDENCE_API_POST_EVIDENCE_REQUESTS_TOKEN"),
                 ActivityHistoryApiUrl = activityApiUrl != null ? new Uri(activityApiUrl) : null,
+                BlockedAuthEmails = Environment.GetEnvironmentVariable("BLOCKED_AUTH_EMAILS"),
             };
         }
     }

--- a/HousingRegisterApi/V1/Controllers/AuthApiController.cs
+++ b/HousingRegisterApi/V1/Controllers/AuthApiController.cs
@@ -1,5 +1,6 @@
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.UseCase;
 using HousingRegisterApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -38,8 +39,15 @@ namespace HousingRegisterApi.V1.Controllers
         [Route("generate")]
         public IActionResult GenerateCode([FromBody] CreateAuthRequest request)
         {
-            var result = _createAuthUseCase.Execute(request);
-            return Ok(result);
+            try
+            {
+                var result = _createAuthUseCase.Execute(request);
+                return Ok(result);
+            }
+            catch (AuthGenerateBlockedException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
         }
 
         /// <summary>

--- a/HousingRegisterApi/V1/Infrastructure/BlockedAuthEmailMatcher.cs
+++ b/HousingRegisterApi/V1/Infrastructure/BlockedAuthEmailMatcher.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HousingRegisterApi.V1.Infrastructure
+{
+    public static class BlockedAuthEmailMatcher
+    {
+        public static bool IsBlocked(string email, string blockedEmailsConfig)
+        {
+            if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(blockedEmailsConfig))
+            {
+                return false;
+            }
+
+            var normalizedEmail = email.Trim().ToLowerInvariant();
+            var rules = ParseRules(blockedEmailsConfig);
+
+            return rules.Any(rule => MatchesRule(normalizedEmail, rule));
+        }
+
+        private static IEnumerable<string> ParseRules(string blockedEmailsConfig)
+        {
+            return blockedEmailsConfig
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(rule => rule.Trim().ToLowerInvariant())
+                .Where(rule => !string.IsNullOrEmpty(rule));
+        }
+
+        private static bool MatchesRule(string normalizedEmail, string rule)
+        {
+            if (rule.StartsWith("*@", StringComparison.Ordinal))
+            {
+                var domain = rule[1..];
+                return normalizedEmail.EndsWith(domain, StringComparison.Ordinal);
+            }
+
+            return normalizedEmail == rule;
+        }
+    }
+}

--- a/HousingRegisterApi/V1/UseCase/AuthGenerateBlockedException.cs
+++ b/HousingRegisterApi/V1/UseCase/AuthGenerateBlockedException.cs
@@ -1,0 +1,12 @@
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
+
+namespace HousingRegisterApi.V1.UseCase
+{
+    public class AuthGenerateBlockedException : HousingRegisterException
+    {
+        public AuthGenerateBlockedException()
+            : base("Unable to generate a verification code for this email address.")
+        {
+        }
+    }
+}

--- a/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
 using HousingRegisterApi.V1.Domain;
@@ -14,19 +15,27 @@ namespace HousingRegisterApi.V1.UseCase
         private readonly IApplicationApiGateway _applicationGateway;
         private readonly INotifyGateway _notifyGateway;
         private readonly IActivityGateway _activityGateway;
+        private readonly ApiOptions _apiOptions;
 
         public CreateAuthUseCase(
             IApplicationApiGateway applicationGateway,
             INotifyGateway notifyGateway,
-            IActivityGateway activityGateway)
+            IActivityGateway activityGateway,
+            ApiOptions apiOptions)
         {
             _applicationGateway = applicationGateway;
             _notifyGateway = notifyGateway;
             _activityGateway = activityGateway;
+            _apiOptions = apiOptions;
         }
 
         public CreateAuthResponse Execute(CreateAuthRequest request)
         {
+            if (BlockedAuthEmailMatcher.IsBlocked(request.Email, _apiOptions.BlockedAuthEmails))
+            {
+                throw new AuthGenerateBlockedException();
+            }
+
             // check if an uncompleted application exists
             // if so, use that, or create a blank one
             var incompleteApplication = _applicationGateway.GetIncompleteApplication(request.Email);

--- a/HousingRegisterApi/serverless.yml
+++ b/HousingRegisterApi/serverless.yml
@@ -20,7 +20,7 @@ provider:
         rateLimit: 100
     binaryMediaTypes:
       - 'text/csv'
-      
+
 package:
   artifact: ./bin/release/net8.0/housing-register-api.zip
 
@@ -47,6 +47,7 @@ functions:
       NOVALET_FTP_USERNAME: ${param:novaletFtpUsername}
       NOVALET_FTP_ADDRESS: ${param:novaletFtpAddress}
       NOVALET_FTP_PORT: ${param:novaletFtpPort}
+      BLOCKED_AUTH_EMAILS: ${ssm:/housing-register/${self:provider.stage}/blocked-auth-emails, ''}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
## What
Blocks configured email addresses from starting the resident auth flow via POST /api/v1/auth/generate, preventing scanners (e.g. Probely) from creating application records in production.

The blocklist is driven by an SSM parameter per environment, so it can be updated without a deployment.

## Why
After the v2.2.1 release, Probely could successfully submit /api/auth/generate with scanner@prbly.win, which created blank application records in production. This adds a backend guard while Probely configuration is reviewed.

## Changes

- Added BLOCKED_AUTH_EMAILS env var from SSM: /housing-register/{stage}/blocked-auth-emails
- Added BlockedAuthEmailMatcher supporting comma-separated rules:
--exact emails: scanner@prbly.win
--domain wildcards: *@prbly.win
- CreateAuthUseCase checks the blocklist before creating or updating any application
- Blocked requests return 404 with: Unable to generate a verification code for this email address.
- No application record is created and no Notify email is sent for blocked addresses
- Frontend forwards backend HTTP status codes (including 404) instead of always returning 500

## Configuration
SSM parameter is managed in the central parameter store. Dev/staging can omit the parameter (defaults to empty string) or set it empty.

## Test plan

- [ ] Deploy API to production with SSM param set
- [ ]  POST /api/v1/auth/generate with scanner@prbly.win returns 404 and no new application is created
- [ ]  POST /api/v1/auth/generate with a legitimate resident email still returns 200
- [ ]  Run Probely scan in normal mode 
- [ ] Frontend sign-in with a blocked email surfaces the backend error (not a generic 500)