### PR TITLE
Feature: validate post route

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,63 +102,12 @@ commands:
           keys:
             - npm-serverless-v4
       - run:
-          name: Install Node and AWS CLI
+          name: Install Node
           command: |
             apt-get update
-            apt-get install -y curl ca-certificates awscli
+            apt-get install -y curl ca-certificates
             curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
             apt-get install -y nodejs
-      - run:
-          name: Fetch SSM parameters from central account for serverless deployment
-          command: |
-            CENTRAL_ACCOUNT=${<<parameters.aws-central-parameter-account>>}
-            export EVIDENCE_API=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/mtfh-housing/evidence-api-url \
-              --query Parameter.Value \
-              --output text)
-            export ACTIVITY_HISTORY_API=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/mtfh-housing-<<parameters.stage>>/mtfh-housing/activity-history-api-url \
-              --query Parameter.Value \
-              --output text)
-            export SEARCH_DOMAIN=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/search-domain \
-              --query Parameter.Value \
-              --output text)
-            export NOTIFY_TEMPLATE_BEDROOM_CHANGE=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/notify-template-bedroom-change \
-              --query Parameter.Value \
-              --output text)
-            export EVIDENCE_API_REQUESTED_BY=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/evidence-api-requested-by-email \
-              --query Parameter.Value \
-              --output text)
-            export NOVALET_FTP_USERNAME=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/novalet-ftp-username \
-              --query Parameter.Value \
-              --output text)
-            export NOVALET_FTP_ADDRESS=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/novalet-ftp-address \
-              --query Parameter.Value \
-              --output text)
-            export NOVALET_FTP_PORT=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/novalet-ftp-port \
-              --query Parameter.Value \
-              --output text)
-            export NOVALET_FTP_FOLDER=$(aws ssm get-parameter \
-              --name arn:aws:ssm:eu-west-2:${CENTRAL_ACCOUNT}:parameter/housing-<<parameters.stage>>/housing-register-<<parameters.stage>>/housing-register/novalet-ftp-folder \
-              --query Parameter.Value \
-              --output text)
-
-            echo "export EVIDENCE_API=${EVIDENCE_API}" >> $BASH_ENV
-            echo "export ACTIVITY_HISTORY_API=${ACTIVITY_HISTORY_API}" >> $BASH_ENV
-            echo "export SEARCH_DOMAIN=${SEARCH_DOMAIN}" >> $BASH_ENV
-            echo "export NOTIFY_TEMPLATE_BEDROOM_CHANGE=${NOTIFY_TEMPLATE_BEDROOM_CHANGE}" >> $BASH_ENV
-            echo "export EVIDENCE_API_REQUESTED_BY=${EVIDENCE_API_REQUESTED_BY}" >> $BASH_ENV
-            echo "export NOVALET_FTP_USERNAME=${NOVALET_FTP_USERNAME}" >> $BASH_ENV
-            echo "export NOVALET_FTP_ADDRESS=${NOVALET_FTP_ADDRESS}" >> $BASH_ENV
-            echo "export NOVALET_FTP_PORT=${NOVALET_FTP_PORT}" >> $BASH_ENV
-            echo "export NOVALET_FTP_FOLDER=${NOVALET_FTP_FOLDER}" >> $BASH_ENV
-
       - run:
           name: Build and deploy lambda
           command: |
@@ -169,15 +118,7 @@ commands:
 
             npx --yes serverless@4 deploy \
               --stage <<parameters.stage>> \
-              --param="evidenceApi=${EVIDENCE_API}" \
-              --param="activityHistoryApi=${ACTIVITY_HISTORY_API}" \
-              --param="searchDomain=${SEARCH_DOMAIN}" \
-              --param="notifyTemplateBedroomChange=${NOTIFY_TEMPLATE_BEDROOM_CHANGE}" \
-              --param="evidenceApiRequestedBy=${EVIDENCE_API_REQUESTED_BY}" \
-              --param="novaletFtpUsername=${NOVALET_FTP_USERNAME}" \
-              --param="novaletFtpAddress=${NOVALET_FTP_ADDRESS}" \
-              --param="novaletFtpPort=${NOVALET_FTP_PORT}" \
-              --param="novaletFtpFolder=${NOVALET_FTP_FOLDER}" \
+              --param="centralAccount=${<<parameters.aws-central-parameter-account>>}" \
               --conceal
       - save_cache:
           name: Save NuGet cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@2.0.0
+  aws_assume_role: lbh-hackit/aws_assume_role@0.1.1
+  sonarcloud: sonarsource/sonarcloud@4.0.0
 
 executors:
   docker-python:

--- a/.editorconfig
+++ b/.editorconfig
@@ -50,6 +50,7 @@ dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_inte
 dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_symbols.private_internal_fields.required_modifiers = readonly
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+secret:
+  ignored_matches:
+    - name: E2E dummy staff JWT (test fixture, not a production secret)
+      match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw

--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,6 +1,0 @@
-version: 2
-
-secret:
-  ignored_matches:
-    - name: E2E dummy staff JWT (test fixture, not a production secret)
-      match: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw

--- a/HousingRegisterApi.Tests/DynamoDbIntegrationTests.cs
+++ b/HousingRegisterApi.Tests/DynamoDbIntegrationTests.cs
@@ -36,6 +36,7 @@ namespace HousingRegisterApi.Tests
 
         public DynamoDbIntegrationTests()
         {
+            E2eHostConfiguration.Apply();
             EnsureEnvVarConfigured("DynamoDb_LocalMode", "true");
             EnsureEnvVarConfigured("DynamoDb_LocalServiceUrl", "http://localhost:8000");
             EnsureEnvVarConfigured("Localstack_SnsServiceUrl", "http://localhost:4566");

--- a/HousingRegisterApi.Tests/DynamoDbMockWebApplicationFactory.cs
+++ b/HousingRegisterApi.Tests/DynamoDbMockWebApplicationFactory.cs
@@ -5,6 +5,7 @@ using Amazon.S3;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using Amazon.SQS;
+using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Domain.Sns;
 using HousingRegisterApi.V1.Infrastructure;
 using Microsoft.AspNetCore.Hosting;
@@ -16,6 +17,7 @@ using Moq;
 using Notify.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace HousingRegisterApi.Tests
 {
@@ -38,6 +40,8 @@ namespace HousingRegisterApi.Tests
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
+            E2eHostConfiguration.Apply();
+
             builder.ConfigureAppConfiguration(b => b.AddEnvironmentVariables())
                 .UseStartup<Startup>();
 
@@ -71,6 +75,16 @@ namespace HousingRegisterApi.Tests
             // lets not send emails, but mock them
             builder.ConfigureTestServices(services =>
             {
+                E2eHostConfiguration.Apply();
+
+                var apiOptionsDescriptor = services
+                    .FirstOrDefault(descriptor => descriptor.ServiceType == typeof(ApiOptions));
+                if (apiOptionsDescriptor != null)
+                {
+                    services.Remove(apiOptionsDescriptor);
+                }
+
+                services.AddSingleton(E2eHostConfiguration.CreateApiOptions());
                 services.AddTransient(x => new Mock<INotificationClient>().Object);
             });
         }

--- a/HousingRegisterApi.Tests/E2eHostConfiguration.cs
+++ b/HousingRegisterApi.Tests/E2eHostConfiguration.cs
@@ -1,0 +1,38 @@
+using System;
+using HousingRegisterApi.Tests.V1.E2ETests.Fixtures;
+using HousingRegisterApi.V1;
+
+namespace HousingRegisterApi.Tests
+{
+    /// <summary>
+    /// Wires the API host for DynamoDB integration tests.
+    /// </summary>
+    /// <remarks>
+    /// You do not need to set <c>HACKNEY_JWT_SECRET</c> yourself to run these tests.
+    /// <see cref="Apply"/> is called automatically by <see cref="DynamoDbIntegrationTests{TStartup}"/>
+    /// and <see cref="DynamoDbMockWebApplicationFactory{TStartup}"/> before the host starts.
+    ///
+    /// The API reads <c>HACKNEY_JWT_SECRET</c> at runtime (e.g. resident token generation in
+    /// <c>TokenGenerator</c>), so the test host must expose that variable name. The value applied
+    /// here is always <see cref="E2eStaffTokenHelper.TestJwtSecret"/> — a fixed dummy string used
+    /// only in tests. It is not the production secret from SSM and must never be treated as one.
+    /// </remarks>
+    internal static class E2eHostConfiguration
+    {
+        internal static void Apply()
+        {
+            Environment.SetEnvironmentVariable("AUTHORISED_OFFICER_GROUP", E2eStaffTokenHelper.StaffGroup);
+
+            // Test-only value; overwrites any local .env so E2E never depends on a real JWT secret.
+            Environment.SetEnvironmentVariable("HACKNEY_JWT_SECRET", E2eStaffTokenHelper.TestJwtSecret);
+        }
+
+        internal static ApiOptions CreateApiOptions()
+        {
+            var options = ApiOptions.FromEnv();
+            options.HackneyJwtSecret = E2eStaffTokenHelper.TestJwtSecret;
+            options.AuthorisedOfficerGroup = E2eStaffTokenHelper.StaffGroup;
+            return options;
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/HousingRegisterApi.Tests.csproj
+++ b/HousingRegisterApi.Tests/HousingRegisterApi.Tests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <Compile Include="V1\E2ETests\Fixtures\ApplicationFixture.cs" />
+    <Compile Include="V1\E2ETests\Fixtures\E2eStaffTokenHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
@@ -15,23 +15,11 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
     //For guidance on writing integration tests see the wiki page https://github.com/LBHackney-IT/lbh-base-api/wiki/Writing-Integration-Tests
     public class CreateNewApplicationTest : DynamoDbIntegrationTests<Startup>
     {
-        private const string StaffToken =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
-
         private readonly ApplicationFixture _applicationFixture;
 
         public CreateNewApplicationTest()
         {
             _applicationFixture = new ApplicationFixture();
-        }
-
-        // StaffAuthValidator reads AUTHORISED_*_GROUP from the environment. The dummy
-        // StaffToken below includes groups: ["e2e-testing"], so this must match for
-        // create-application E2E tests to pass (production values come from SSM).
-        [OneTimeSetUp]
-        public void SetUpStaffGroups()
-        {
-            Environment.SetEnvironmentVariable("AUTHORISED_OFFICER_GROUP", "e2e-testing");
         }
 
         private async Task<HttpResponseMessage> PostTestRequestAsync(string input, bool includeStaffToken = false)
@@ -48,7 +36,9 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             {
                 Content = data,
             };
-            message.Headers.Add("Authorization", StaffToken);
+            message.Headers.Add(
+                "Authorization",
+                E2eStaffTokenHelper.CreateStaffAuthorizationHeaderValue());
 
             return await Client.SendAsync(message).ConfigureAwait(false);
         }

--- a/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -14,6 +15,9 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
     //For guidance on writing integration tests see the wiki page https://github.com/LBHackney-IT/lbh-base-api/wiki/Writing-Integration-Tests
     public class CreateNewApplicationTest : DynamoDbIntegrationTests<Startup>
     {
+        private const string StaffToken =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
+
         private readonly ApplicationFixture _applicationFixture;
 
         public CreateNewApplicationTest()
@@ -21,11 +25,29 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             _applicationFixture = new ApplicationFixture();
         }
 
-        private async Task<HttpResponseMessage> PostTestRequestAsync(string input)
+        [OneTimeSetUp]
+        public void SetUpStaffGroups()
+        {
+            Environment.SetEnvironmentVariable("AUTHORISED_OFFICER_GROUP", "e2e-testing");
+        }
+
+        private async Task<HttpResponseMessage> PostTestRequestAsync(string input, bool includeStaffToken = false)
         {
             using var data = new StringContent(input, Encoding.UTF8, "application/json");
             var uri = new Uri($"api/v1/applications/", UriKind.Relative);
-            return await Client.PostAsync(uri, data).ConfigureAwait(false);
+
+            if (!includeStaffToken)
+            {
+                return await Client.PostAsync(uri, data).ConfigureAwait(false);
+            }
+
+            var message = new HttpRequestMessage(HttpMethod.Post, uri)
+            {
+                Content = data,
+            };
+            message.Headers.Add("Authorization", StaffToken);
+
+            return await Client.SendAsync(message).ConfigureAwait(false);
         }
 
         [Test]
@@ -36,7 +58,7 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             var json = JsonConvert.SerializeObject(request);
 
             // Act
-            var response = await PostTestRequestAsync(json).ConfigureAwait(false);
+            var response = await PostTestRequestAsync(json, includeStaffToken: true).ConfigureAwait(false);
             response.StatusCode.Should().Be(HttpStatusCode.Created);
 
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -50,6 +72,17 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             apiEntity.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, 5000);
             apiEntity.MainApplicant.Should().BeEquivalentTo(request.MainApplicant);
             apiEntity.OtherMembers.Should().BeEquivalentTo(request.OtherMembers);
+        }
+
+        [Test]
+        public async Task CreateNewApplicationReturnsForbiddenWithoutStaffToken()
+        {
+            var request = _applicationFixture.ConstructCreateApplicationRequest();
+            var json = JsonConvert.SerializeObject(request);
+
+            var response = await PostTestRequestAsync(json).ConfigureAwait(false);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
         }
 
         [Test]

--- a/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
@@ -25,6 +25,9 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             _applicationFixture = new ApplicationFixture();
         }
 
+        // StaffAuthValidator reads AUTHORISED_*_GROUP from the environment. The dummy
+        // StaffToken below includes groups: ["e2e-testing"], so this must match for
+        // create-application E2E tests to pass (production values come from SSM).
         [OneTimeSetUp]
         public void SetUpStaffGroups()
         {

--- a/HousingRegisterApi.Tests/V1/E2ETests/Fixtures/E2eStaffTokenHelper.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/Fixtures/E2eStaffTokenHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace HousingRegisterApi.Tests.V1.E2ETests.Fixtures
+{
+    /// <summary>
+    /// Builds Hackney staff JWTs for E2E tests using the same claim shape as LBH Google auth.
+    /// </summary>
+    public static class E2eStaffTokenHelper
+    {
+        public const string StaffEmail = "e2e-testing@development.com";
+        public const string StaffName = "Tester";
+        public const string StaffGroup = "e2e-testing";
+        public const string TestJwtSecret = "e2e-test-only-jwt-secret";
+
+        public static string CreateStaffAuthorizationHeaderValue(string group = StaffGroup)
+        {
+            var signingCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.ASCII.GetBytes(TestJwtSecret)),
+                SecurityAlgorithms.HmacSha256Signature);
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            var payload = new JwtPayload(
+                issuer: "Hackney",
+                audience: null,
+                claims: new List<Claim>
+                {
+                    new Claim("sub", "115018116092098676113"),
+                    new Claim("email", StaffEmail),
+                    new Claim("name", StaffName),
+                },
+                notBefore: null,
+                expires: null,
+                issuedAt: DateTime.UtcNow);
+            payload.Add("groups", new[] { group });
+
+            var token = new JwtSecurityToken(new JwtHeader(signingCredentials), payload);
+
+            return tokenHandler.WriteToken(token);
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/V1/E2ETests/UpdateApplicationTest.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/UpdateApplicationTest.cs
@@ -22,8 +22,6 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
     public class UpdateApplicationTest : DynamoDbIntegrationTests<Startup>
     {
         private readonly ApplicationFixture _applicationFixture;
-        private const string Token =
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
 
         public UpdateApplicationTest()
         {
@@ -44,7 +42,9 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             var uri = new Uri($"api/v1/applications/{id}", UriKind.Relative);
 
             var message = new HttpRequestMessage(HttpMethod.Patch, uri);
-            message.Headers.Add("Authorization", Token);
+            message.Headers.Add(
+                "Authorization",
+                E2eStaffTokenHelper.CreateStaffAuthorizationHeaderValue());
 
             message.Content = new StringContent(input, Encoding.UTF8, "application/json");
             message.Method = HttpMethod.Patch;
@@ -73,8 +73,8 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             message.Id.Should().NotBeEmpty();
             message.SourceDomain.Should().Be(UpdateApplicationConstants.SOURCEDOMAIN);
             message.SourceSystem.Should().Be(UpdateApplicationConstants.SOURCESYSTEM);
-            message.User.Email.Should().Be("e2e-testing@development.com");
-            message.User.Name.Should().Be("Tester");
+            message.User.Email.Should().Be(E2eStaffTokenHelper.StaffEmail);
+            message.User.Name.Should().Be(E2eStaffTokenHelper.StaffName);
             message.Version.Should().Be(UpdateApplicationConstants.V1VERSION);
         }
 

--- a/HousingRegisterApi.Tests/V1/Infrastructure/AuthEmailValidatorTests.cs
+++ b/HousingRegisterApi.Tests/V1/Infrastructure/AuthEmailValidatorTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using HousingRegisterApi.V1.Infrastructure;
+using NUnit.Framework;
+
+namespace HousingRegisterApi.Tests.V1.Infrastructure
+{
+    public class AuthEmailValidatorTests
+    {
+        [TestCase("resident@hackney.gov.uk")]
+        [TestCase("user.name+tag@example.com")]
+        [TestCase("  resident@hackney.gov.uk  ")]
+        public void IsValidReturnsTrueForValidEmailAddresses(string email)
+        {
+            AuthEmailValidator.IsValid(email).Should().BeTrue();
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("not-an-email")]
+        [TestCase("' OR 1=1 --")]
+        [TestCase("scanner@prbly.win'; DROP TABLE users; --")]
+        [TestCase("@missing-local-part.com")]
+        [TestCase("missing-domain@")]
+        public void IsValidReturnsFalseForInvalidEmailAddresses(string email)
+        {
+            AuthEmailValidator.IsValid(email).Should().BeFalse();
+        }
+
+        [Test]
+        public void IsValidReturnsFalseWhenEmailExceedsMaxLength()
+        {
+            var localPart = new string('a', 250);
+            var email = $"{localPart}@example.com";
+
+            AuthEmailValidator.IsValid(email).Should().BeFalse();
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/V1/Infrastructure/E2eStaffTokenHelperTests.cs
+++ b/HousingRegisterApi.Tests/V1/Infrastructure/E2eStaffTokenHelperTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Hackney.Core.JWT;
+using HousingRegisterApi.Tests.V1.E2ETests.Fixtures;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace HousingRegisterApi.Tests.V1.Infrastructure
+{
+    public class E2eStaffTokenHelperTests
+    {
+        [Test]
+        public void CreateStaffAuthorizationHeaderValueIsDecodedByTokenFactory()
+        {
+            var tokenFactory = new ServiceCollection()
+                .AddLogging()
+                .AddTokenFactory()
+                .BuildServiceProvider()
+                .GetRequiredService<ITokenFactory>();
+            var headers = new HeaderDictionary
+            {
+                { "Authorization", E2eStaffTokenHelper.CreateStaffAuthorizationHeaderValue() },
+            };
+
+            var token = tokenFactory.Create(headers);
+
+            token.Should().NotBeNull();
+            token.Email.Should().Be(E2eStaffTokenHelper.StaffEmail);
+            token.Name.Should().Be(E2eStaffTokenHelper.StaffName);
+            token.Groups.Should().Contain(E2eStaffTokenHelper.StaffGroup);
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/V1/Infrastructure/StaffAuthValidatorTests.cs
+++ b/HousingRegisterApi.Tests/V1/Infrastructure/StaffAuthValidatorTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Hackney.Core.JWT;
+using HousingRegisterApi.V1;
+using HousingRegisterApi.V1.Infrastructure;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace HousingRegisterApi.Tests.V1.Infrastructure
+{
+    public class StaffAuthValidatorTests
+    {
+        [Test]
+        public void GetStaffGroupsAllowedToCreateApplicationsExcludesReadOnlyGroup()
+        {
+            var options = new ApiOptions
+            {
+                AuthorisedAdminGroup = "admin-group",
+                AuthorisedManagerGroup = "manager-group",
+                AuthorisedOfficerGroup = "officer-group",
+                AuthorisedReadOnlyGroup = "read-only-group",
+            };
+
+            options.GetStaffGroupsAllowedToCreateApplications()
+                .Should()
+                .BeEquivalentTo(new[] { "admin-group", "manager-group", "officer-group" });
+        }
+
+        [Test]
+        public void GetStaffGroupsAllowedToCreateApplicationsIgnoresBlankValues()
+        {
+            var options = new ApiOptions
+            {
+                AuthorisedOfficerGroup = "officer-group",
+            };
+
+            options.GetStaffGroupsAllowedToCreateApplications()
+                .Should()
+                .BeEquivalentTo(new[] { "officer-group" });
+        }
+    }
+}

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Domain;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.UseCase;
@@ -20,6 +21,7 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         private ApiOptions _apiOptions;
         private CreateAuthUseCase _classUnderTest;
         private Fixture _fixture;
+        private const string ValidEmail = "resident@hackney.gov.uk";
 
         [SetUp]
         public void SetUp()
@@ -51,7 +53,10 @@ namespace HousingRegisterApi.Tests.V1.UseCase
                 .Returns(application);
 
             // Act
-            var response = _classUnderTest.Execute(new CreateAuthRequest());
+            var response = _classUnderTest.Execute(new CreateAuthRequest
+            {
+                Email = ValidEmail
+            });
 
             // Assert
             _mockApplicationGateway.Verify(x => x.CreateVerifyCode(application.Id, It.IsAny<CreateAuthRequest>()));
@@ -77,11 +82,34 @@ namespace HousingRegisterApi.Tests.V1.UseCase
                 .Returns(application);
 
             // Act
-            var response = _classUnderTest.Execute(new CreateAuthRequest());
+            var response = _classUnderTest.Execute(new CreateAuthRequest
+            {
+                Email = ValidEmail
+            });
 
             // Assert
             _mockApplicationGateway.Verify(x => x.CreateVerifyCode(It.IsAny<Guid>(), It.IsAny<CreateAuthRequest>()));
             response.Should().BeOfType<CreateAuthResponse>();
+        }
+
+        [Test]
+        public void CreateVerifyCodeThrowsWhenEmailIsInvalid()
+        {
+            Action act = () => _classUnderTest.Execute(new CreateAuthRequest
+            {
+                Email = "' OR 1=1 --"
+            });
+
+            act.Should().Throw<InvalidAuthEmailException>();
+            _mockApplicationGateway.Verify(
+                x => x.GetIncompleteApplication(It.IsAny<string>()),
+                Times.Never);
+            _mockApplicationGateway.Verify(
+                x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()),
+                Times.Never);
+            _mockNotifyGateway.Verify(
+                x => x.SendVerifyCode(It.IsAny<Applicant>(), It.IsAny<string>()),
+                Times.Never);
         }
 
         [Test]

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
@@ -1,11 +1,16 @@
 using AutoFixture;
 using FluentAssertions;
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Domain;
 using HousingRegisterApi.V1.Factories;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.UseCase;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -16,6 +21,10 @@ namespace HousingRegisterApi.Tests.V1.UseCase
     {
         private Mock<IApplicationApiGateway> _mockGateway;
         private Mock<IActivityGateway> _mockActivityGateway;
+        private Mock<IHttpContextAccessor> _mockContextAccessor;
+        private Mock<IHttpContextWrapper> _mockContextWrapper;
+        private Mock<ITokenFactory> _mockTokenFactory;
+        private ApiOptions _apiOptions;
         private CreateNewApplicationUseCase _classUnderTest;
         private Fixture _fixture;
 
@@ -24,40 +33,93 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         {
             _mockGateway = new Mock<IApplicationApiGateway>();
             _mockActivityGateway = new Mock<IActivityGateway>();
-            _classUnderTest = new CreateNewApplicationUseCase(_mockGateway.Object, _mockActivityGateway.Object);
+            _mockContextAccessor = new Mock<IHttpContextAccessor>();
+            _mockContextWrapper = new Mock<IHttpContextWrapper>();
+            _mockTokenFactory = new Mock<ITokenFactory>();
+            _apiOptions = new ApiOptions
+            {
+                AuthorisedOfficerGroup = "officer-group",
+            };
+            _classUnderTest = new CreateNewApplicationUseCase(
+                _mockGateway.Object,
+                _mockActivityGateway.Object,
+                _mockContextAccessor.Object,
+                _mockContextWrapper.Object,
+                _mockTokenFactory.Object,
+                _apiOptions);
             _fixture = new Fixture();
+
+            var httpContext = new DefaultHttpContext();
+            _mockContextAccessor
+                .Setup(x => x.HttpContext)
+                .Returns(httpContext);
+            _mockContextWrapper
+                .Setup(x => x.GetContextRequestHeaders(httpContext))
+                .Returns(httpContext.Request.Headers);
         }
 
         [Test]
-        public void CreateNewApplicationCallsGateway()
+        public void CreateNewApplicationCallsGatewayWhenStaffTokenIsAuthorized()
         {
-            // Arrange            
             var application = _fixture.Create<Application>();
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns(new Token { Groups = new[] { "officer-group" } });
             _mockGateway
                 .Setup(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()))
                 .Returns(application);
 
-            // Act
             var response = _classUnderTest.Execute(new CreateApplicationRequest());
 
-            // Assert
             _mockGateway.Verify(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()));
             response.Should().BeEquivalentTo(application.ToResponse());
         }
 
         [Test]
+        public void CreateNewApplicationThrowsWhenStaffTokenIsMissing()
+        {
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns((Token)null);
+
+            Action act = () => _classUnderTest.Execute(new CreateApplicationRequest());
+
+            act.Should().Throw<UnauthorizedStaffException>();
+            _mockGateway.Verify(
+                x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()),
+                Times.Never);
+        }
+
+        [Test]
+        public void CreateNewApplicationThrowsWhenStaffTokenIsReadOnly()
+        {
+            _apiOptions.AuthorisedReadOnlyGroup = "read-only-group";
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns(new Token { Groups = new[] { "read-only-group" } });
+
+            Action act = () => _classUnderTest.Execute(new CreateApplicationRequest());
+
+            act.Should().Throw<UnauthorizedStaffException>();
+            _mockGateway.Verify(
+                x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()),
+                Times.Never);
+        }
+
+        [Test]
         public void CreateNewApplicationExceptionIsThrown()
         {
-            // Arrange
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns(new Token { Groups = new[] { "officer-group" } });
+
             var exception = new ApplicationException("Test exception");
             _mockGateway
                 .Setup(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()))
                 .Throws(exception);
 
-            // Act
             Func<ApplicationResponse> func = () => _classUnderTest.Execute(new CreateApplicationRequest());
 
-            // Assert
             func.Should().Throw<ApplicationException>().WithMessage(exception.Message);
         }
     }

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
@@ -80,7 +80,7 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         {
             _mockTokenFactory
                 .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
-                .Returns((Token)null);
+                .Returns((Token) null);
 
             Action act = () => _classUnderTest.Execute(new CreateApplicationRequest());
 

--- a/HousingRegisterApi.Tests/V1/UseCase/VerifyAuthUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/VerifyAuthUseCaseTests.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using FluentAssertions;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Domain;
 using HousingRegisterApi.V1.Factories;
 using HousingRegisterApi.V1.Gateways;
@@ -19,6 +20,7 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         private Mock<ITokenGenerator> _mockTokenGenerator;
         private VerifyAuthUseCase _classUnderTest;
         private Fixture _fixture;
+        private const string ValidEmail = "resident@hackney.gov.uk";
 
         [SetUp]
         public void SetUp()
@@ -40,11 +42,31 @@ namespace HousingRegisterApi.Tests.V1.UseCase
                 .Returns(application);
 
             // Act
-            var response = _classUnderTest.Execute(new VerifyAuthRequest());
+            var response = _classUnderTest.Execute(new VerifyAuthRequest
+            {
+                Email = ValidEmail,
+                Code = "123456"
+            });
 
             // Assert
-            _mockGateway.Verify(x => x.ConfirmVerifyCode(It.IsAny<VerifyAuthRequest>()));
+            _mockGateway.Verify(x => x.ConfirmVerifyCode(It.Is<VerifyAuthRequest>(r =>
+                r.Email == ValidEmail && r.Code == "123456")));
             response.Should().BeOfType<VerifyAuthResponse>();
+        }
+
+        [Test]
+        public void ConfirmVerifyCodeThrowsWhenEmailIsInvalid()
+        {
+            Action act = () => _classUnderTest.Execute(new VerifyAuthRequest
+            {
+                Email = "not-an-email",
+                Code = "123456"
+            });
+
+            act.Should().Throw<InvalidAuthEmailException>();
+            _mockGateway.Verify(
+                x => x.ConfirmVerifyCode(It.IsAny<VerifyAuthRequest>()),
+                Times.Never);
         }
     }
 }

--- a/HousingRegisterApi/V1/ApiOptions.cs
+++ b/HousingRegisterApi/V1/ApiOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace HousingRegisterApi.V1
 {
@@ -19,6 +21,24 @@ namespace HousingRegisterApi.V1
         /// </summary>
         public string BlockedAuthEmails { get; set; }
 
+        public string AuthorisedAdminGroup { get; set; }
+
+        public string AuthorisedManagerGroup { get; set; }
+
+        public string AuthorisedOfficerGroup { get; set; }
+
+        public string AuthorisedReadOnlyGroup { get; set; }
+
+        public IEnumerable<string> GetStaffGroupsAllowedToCreateApplications()
+        {
+            return new[]
+            {
+                AuthorisedAdminGroup,
+                AuthorisedManagerGroup,
+                AuthorisedOfficerGroup,
+            }.Where(group => !string.IsNullOrWhiteSpace(group));
+        }
+
         public static ApiOptions FromEnv()
         {
             var evidenceApiUrl = Environment.GetEnvironmentVariable("EVIDENCE_API_URL");
@@ -35,6 +55,10 @@ namespace HousingRegisterApi.V1
                 EvidenceApiPostClaimsToken = Environment.GetEnvironmentVariable("EVIDENCE_API_POST_EVIDENCE_REQUESTS_TOKEN"),
                 ActivityHistoryApiUrl = activityApiUrl != null ? new Uri(activityApiUrl) : null,
                 BlockedAuthEmails = Environment.GetEnvironmentVariable("BLOCKED_AUTH_EMAILS"),
+                AuthorisedAdminGroup = Environment.GetEnvironmentVariable("AUTHORISED_ADMIN_GROUP"),
+                AuthorisedManagerGroup = Environment.GetEnvironmentVariable("AUTHORISED_MANAGER_GROUP"),
+                AuthorisedOfficerGroup = Environment.GetEnvironmentVariable("AUTHORISED_OFFICER_GROUP"),
+                AuthorisedReadOnlyGroup = Environment.GetEnvironmentVariable("AUTHORISED_READONLY_GROUP"),
             };
         }
     }

--- a/HousingRegisterApi/V1/Boundary/Response/Exceptions/InvalidAuthEmailException.cs
+++ b/HousingRegisterApi/V1/Boundary/Response/Exceptions/InvalidAuthEmailException.cs
@@ -1,0 +1,10 @@
+namespace HousingRegisterApi.V1.Boundary.Response.Exceptions
+{
+    public class InvalidAuthEmailException : HousingRegisterException
+    {
+        public InvalidAuthEmailException()
+            : base("Email address is not valid.")
+        {
+        }
+    }
+}

--- a/HousingRegisterApi/V1/Boundary/Response/Exceptions/UnauthorizedStaffException.cs
+++ b/HousingRegisterApi/V1/Boundary/Response/Exceptions/UnauthorizedStaffException.cs
@@ -1,0 +1,10 @@
+namespace HousingRegisterApi.V1.Boundary.Response.Exceptions
+{
+    public class UnauthorizedStaffException : HousingRegisterException
+    {
+        public UnauthorizedStaffException()
+            : base("Staff authorization is required to create an application.")
+        {
+        }
+    }
+}

--- a/HousingRegisterApi/V1/Controllers/ApplicationsApiController.cs
+++ b/HousingRegisterApi/V1/Controllers/ApplicationsApiController.cs
@@ -1,5 +1,6 @@
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -194,15 +195,24 @@ namespace HousingRegisterApi.V1.Controllers
         /// </summary>
         /// <response code="201">Returns the application created with its ID</response>
         /// <response code="400">Invalid fields in the post parameter.</response>
+        /// <response code="403">Staff authorization required</response>
         /// <response code="500">Internal server error</response>
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         public IActionResult CreateNewApplication([FromBody] CreateApplicationRequest applicationRequest)
         {
-            var newApplication = _createNewApplicationUseCase.Execute(applicationRequest);
-            return Created(new Uri($"api/v1/applications/{newApplication.Id}", UriKind.Relative), newApplication);
+            try
+            {
+                var newApplication = _createNewApplicationUseCase.Execute(applicationRequest);
+                return Created(new Uri($"api/v1/applications/{newApplication.Id}", UriKind.Relative), newApplication);
+            }
+            catch (UnauthorizedStaffException ex)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+            }
         }
 
         /// <summary>

--- a/HousingRegisterApi/V1/Controllers/AuthApiController.cs
+++ b/HousingRegisterApi/V1/Controllers/AuthApiController.cs
@@ -1,5 +1,6 @@
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.UseCase;
 using HousingRegisterApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
@@ -30,9 +31,11 @@ namespace HousingRegisterApi.V1.Controllers
         /// Generate a verify code for an existing application
         /// </summary>
         /// <response code="200">Success</response>
+        /// <response code="400">Invalid email address</response>
         /// <response code="404">Application not found</response>
         /// <response code="500">Internal server error</response>
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
@@ -44,6 +47,10 @@ namespace HousingRegisterApi.V1.Controllers
                 var result = _createAuthUseCase.Execute(request);
                 return Ok(result);
             }
+            catch (InvalidAuthEmailException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
             catch (AuthGenerateBlockedException ex)
             {
                 return NotFound(new { message = ex.Message });
@@ -54,19 +61,28 @@ namespace HousingRegisterApi.V1.Controllers
         /// Verfies and email and verification code belong to an application
         /// </summary>
         /// <response code="200">Success</response>
+        /// <response code="400">Invalid email address</response>
         /// <response code="404">Application not found</response>
         /// <response code="500">Internal server error</response>
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         [Route("verify")]
         public IActionResult VerifyCode([FromBody] VerifyAuthRequest request)
         {
-            var result = _verifyAuthUseCase.Execute(request);
-            if (result == null) return NotFound();
+            try
+            {
+                var result = _verifyAuthUseCase.Execute(request);
+                if (result == null) return NotFound();
 
-            return Ok(result);
+                return Ok(result);
+            }
+            catch (InvalidAuthEmailException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
         }
     }
 }

--- a/HousingRegisterApi/V1/Infrastructure/AuthEmailValidator.cs
+++ b/HousingRegisterApi/V1/Infrastructure/AuthEmailValidator.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace HousingRegisterApi.V1.Infrastructure
+{
+    public static class AuthEmailValidator
+    {
+        private const int MaxEmailLength = 254;
+
+        private static readonly char[] DisallowedCharacters =
+        {
+            '\'', '"', ';', '<', '>', '(', ')', '\\', '\r', '\n', '\0', ' '
+        };
+
+        public static bool IsValid(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                return false;
+            }
+
+            var trimmed = email.Trim();
+
+            if (trimmed.Length > MaxEmailLength)
+            {
+                return false;
+            }
+
+            if (trimmed.IndexOfAny(DisallowedCharacters) >= 0)
+            {
+                return false;
+            }
+
+            if (trimmed.Count(c => c == '@') != 1)
+            {
+                return false;
+            }
+
+            return new EmailAddressAttribute().IsValid(trimmed);
+        }
+    }
+}

--- a/HousingRegisterApi/V1/Infrastructure/AuthEmailValidator.cs
+++ b/HousingRegisterApi/V1/Infrastructure/AuthEmailValidator.cs
@@ -7,7 +7,7 @@ namespace HousingRegisterApi.V1.Infrastructure
     {
         private const int MaxEmailLength = 254;
 
-        private static readonly char[] DisallowedCharacters =
+        private static readonly char[] _disallowedCharacters =
         {
             '\'', '"', ';', '<', '>', '(', ')', '\\', '\r', '\n', '\0', ' '
         };
@@ -26,7 +26,7 @@ namespace HousingRegisterApi.V1.Infrastructure
                 return false;
             }
 
-            if (trimmed.IndexOfAny(DisallowedCharacters) >= 0)
+            if (trimmed.IndexOfAny(_disallowedCharacters) >= 0)
             {
                 return false;
             }

--- a/HousingRegisterApi/V1/Infrastructure/StaffAuthValidator.cs
+++ b/HousingRegisterApi/V1/Infrastructure/StaffAuthValidator.cs
@@ -1,0 +1,58 @@
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using HousingRegisterApi.V1;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HousingRegisterApi.V1.Infrastructure
+{
+    public static class StaffAuthValidator
+    {
+        public static void EnsureCanCreateApplication(
+            HttpContext context,
+            IHttpContextWrapper contextWrapper,
+            ITokenFactory tokenFactory,
+            ApiOptions apiOptions)
+        {
+            if (!TryGetStaffToken(context, contextWrapper, tokenFactory, out var token))
+            {
+                throw new UnauthorizedStaffException();
+            }
+
+            var allowedGroups = apiOptions.GetStaffGroupsAllowedToCreateApplications().ToList();
+            if (!allowedGroups.Any())
+            {
+                throw new UnauthorizedStaffException();
+            }
+
+            if (token.Groups == null ||
+                !token.Groups.Any(group => allowedGroups.Contains(group, StringComparer.OrdinalIgnoreCase)))
+            {
+                throw new UnauthorizedStaffException();
+            }
+        }
+
+        private static bool TryGetStaffToken(
+            HttpContext context,
+            IHttpContextWrapper contextWrapper,
+            ITokenFactory tokenFactory,
+            out Token token)
+        {
+            token = null;
+
+            try
+            {
+                token = tokenFactory.Create(contextWrapper.GetContextRequestHeaders(context));
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+
+            return token != null;
+        }
+    }
+}

--- a/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Domain;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.Infrastructure;
@@ -31,14 +32,21 @@ namespace HousingRegisterApi.V1.UseCase
 
         public CreateAuthResponse Execute(CreateAuthRequest request)
         {
-            if (BlockedAuthEmailMatcher.IsBlocked(request.Email, _apiOptions.BlockedAuthEmails))
+            if (!AuthEmailValidator.IsValid(request?.Email))
+            {
+                throw new InvalidAuthEmailException();
+            }
+
+            var email = request.Email.Trim();
+
+            if (BlockedAuthEmailMatcher.IsBlocked(email, _apiOptions.BlockedAuthEmails))
             {
                 throw new AuthGenerateBlockedException();
             }
 
             // check if an uncompleted application exists
             // if so, use that, or create a blank one
-            var incompleteApplication = _applicationGateway.GetIncompleteApplication(request.Email);
+            var incompleteApplication = _applicationGateway.GetIncompleteApplication(email);
             var applicationId = incompleteApplication?.Id;
 
             if (incompleteApplication == null)
@@ -49,7 +57,7 @@ namespace HousingRegisterApi.V1.UseCase
                     {
                         ContactInformation = new ContactInformation()
                         {
-                            EmailAddress = request.Email
+                            EmailAddress = email
                         }
                     },
                     OtherMembers = new List<Applicant>(),
@@ -69,7 +77,10 @@ namespace HousingRegisterApi.V1.UseCase
             }
 
             // this generates a new verification code and assigns it to the application entity
-            var application = _applicationGateway.CreateVerifyCode(applicationId.Value, request);
+            var application = _applicationGateway.CreateVerifyCode(applicationId.Value, new CreateAuthRequest
+            {
+                Email = email
+            });
             if (application == null)
             {
                 return null;

--- a/HousingRegisterApi/V1/UseCase/CreateNewApplicationUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/CreateNewApplicationUseCase.cs
@@ -1,3 +1,6 @@
+using Hackney.Core.Http;
+using Hackney.Core.JWT;
+using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
 using HousingRegisterApi.V1.Domain;
@@ -5,22 +8,43 @@ using HousingRegisterApi.V1.Factories;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.Infrastructure;
 using HousingRegisterApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Http;
 
 namespace HousingRegisterApi.V1.UseCase
 {
     public class CreateNewApplicationUseCase : ICreateNewApplicationUseCase
     {
         private readonly IApplicationApiGateway _gateway;
-
         private readonly IActivityGateway _activityGateway;
-        public CreateNewApplicationUseCase(IApplicationApiGateway gateway, IActivityGateway activityGateway)
+        private readonly IHttpContextAccessor _contextAccessor;
+        private readonly IHttpContextWrapper _contextWrapper;
+        private readonly ITokenFactory _tokenFactory;
+        private readonly ApiOptions _apiOptions;
+
+        public CreateNewApplicationUseCase(
+            IApplicationApiGateway gateway,
+            IActivityGateway activityGateway,
+            IHttpContextAccessor contextAccessor,
+            IHttpContextWrapper contextWrapper,
+            ITokenFactory tokenFactory,
+            ApiOptions apiOptions)
         {
             _gateway = gateway;
             _activityGateway = activityGateway;
+            _contextAccessor = contextAccessor;
+            _contextWrapper = contextWrapper;
+            _tokenFactory = tokenFactory;
+            _apiOptions = apiOptions;
         }
 
         public ApplicationResponse Execute(CreateApplicationRequest request)
         {
+            StaffAuthValidator.EnsureCanCreateApplication(
+                _contextAccessor.HttpContext,
+                _contextWrapper,
+                _tokenFactory,
+                _apiOptions);
+
             Application application = _gateway.CreateNewApplication(request);
 
             var activity = new EntityActivity<ApplicationActivityType>(ApplicationActivityType.Created,

--- a/HousingRegisterApi/V1/UseCase/VerifyAuthUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/VerifyAuthUseCase.cs
@@ -1,6 +1,7 @@
 using System;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.Infrastructure;
 using HousingRegisterApi.V1.UseCase.Interfaces;
@@ -21,7 +22,18 @@ namespace HousingRegisterApi.V1.UseCase
 
         public VerifyAuthResponse Execute(VerifyAuthRequest request)
         {
-            var application = _gateway.ConfirmVerifyCode(request);
+            if (!AuthEmailValidator.IsValid(request?.Email))
+            {
+                throw new InvalidAuthEmailException();
+            }
+
+            var verifyRequest = new VerifyAuthRequest
+            {
+                Email = request.Email.Trim(),
+                Code = request.Code
+            };
+
+            var application = _gateway.ConfirmVerifyCode(verifyRequest);
             if (application == null)
             {
                 return null;

--- a/HousingRegisterApi/serverless.yml
+++ b/HousingRegisterApi/serverless.yml
@@ -39,15 +39,19 @@ functions:
       NOVALET_FTP_PASSWORD: ${ssm:/housing-register/${self:provider.stage}/novalet/ftp-password, false}
       NOVALET_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/novaletexport-sns-topic/arn}
       HOUSING_REGISTER_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/housingregister/arn}
-      EVIDENCE_API_URL: ${param:evidenceApi}
-      ACTIVITY_HISTORY_API_URL: ${param:activityHistoryApi}
-      SEARCH_DOMAIN: ${param:searchDomain}
-      NOTIFY_TEMPLATE_BEDROOM_CHANGE: ${param:notifyTemplateBedroomChange}
-      EVIDENCE_API_REQUESTED_BY: ${param:evidenceApiRequestedBy}
-      NOVALET_FTP_USERNAME: ${param:novaletFtpUsername}
-      NOVALET_FTP_ADDRESS: ${param:novaletFtpAddress}
-      NOVALET_FTP_PORT: ${param:novaletFtpPort}
+      EVIDENCE_API_URL: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/mtfh-housing-${self:provider.stage}/mtfh-housing/evidence-api-url}
+      ACTIVITY_HISTORY_API_URL: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/mtfh-housing-${self:provider.stage}/mtfh-housing/activity-history-api-url}
+      SEARCH_DOMAIN: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/search-domain}
+      NOTIFY_TEMPLATE_BEDROOM_CHANGE: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/notify-template-bedroom-change}
+      EVIDENCE_API_REQUESTED_BY: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/evidence-api-requested-by-email}
+      NOVALET_FTP_USERNAME: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-username}
+      NOVALET_FTP_ADDRESS: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-address}
+      NOVALET_FTP_PORT: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-port}
       BLOCKED_AUTH_EMAILS: ${ssm:/housing-register/${self:provider.stage}/blocked-auth-emails, ''}
+      AUTHORISED_ADMIN_GROUP: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/authorised-admin-group}
+      AUTHORISED_MANAGER_GROUP: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/authorised-manager-group}
+      AUTHORISED_OFFICER_GROUP: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/authorised-officer-group}
+      AUTHORISED_READONLY_GROUP: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/authorised-readonly-group}
     events:
       - http:
           path: /{proxy+}
@@ -61,7 +65,7 @@ functions:
     environment:
       NOTIFY_API_KEY: ${ssm:/housing-register/${self:provider.stage}/notify-api-key}
       HOUSING_REGISTER_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/housingregister/arn}
-      NOTIFY_TEMPLATE_BEDROOM_CHANGE: ${param:notifyTemplateBedroomChange}
+      NOTIFY_TEMPLATE_BEDROOM_CHANGE: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/notify-template-bedroom-change}
     events:
       - schedule: rate(1 hour)
   HousingRegisterNovaletExportGenerator:
@@ -92,10 +96,10 @@ functions:
     timeout: 300
     environment:
       NOVALET_FTP_PASSWORD: ${ssm:/housing-register/${self:provider.stage}/novalet/ftp-password}
-      NOVALET_FTP_USERNAME: ${param:novaletFtpUsername}
-      NOVALET_FTP_ADDRESS: ${param:novaletFtpAddress}
-      NOVALET_FTP_PORT: ${param:novaletFtpPort}
-      NOVALET_FTP_FOLDER: ${param:novaletFtpFolder}
+      NOVALET_FTP_USERNAME: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-username}
+      NOVALET_FTP_ADDRESS: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-address}
+      NOVALET_FTP_PORT: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-port}
+      NOVALET_FTP_FOLDER: ${ssm:arn:aws:ssm:eu-west-2:${param:centralAccount}:parameter/housing-${self:provider.stage}/housing-register-${self:provider.stage}/housing-register/novalet-ftp-folder}
     events:
       - schedule: cron(30 16 ? * MON-FRI *)
 resources:

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,26 @@
 .PHONY: setup
 setup:
-	docker-compose build
+	docker compose build
 
 .PHONY: build
 build:
-	docker-compose build housing-register-api
+	docker compose build housing-register-api
 
 .PHONY: serve
 serve:
-	docker-compose build housing-register-api && docker-compose up housing-register-api
+	docker compose build housing-register-api && docker compose up housing-register-api
 
 serve-from-aws:
-	docker-compose build housing-register-api-remote && docker-compose up housing-register-api-remote
+	docker compose build housing-register-api-remote && docker compose up housing-register-api-remote
 
 .PHONY: shell
 shell:
-	docker-compose run housing-register-api bash
+	docker compose run housing-register-api bash
 
 .PHONY: test
 test:
-	docker-compose up -d dynamodb-database
-	docker-compose build housing-register-api-test && docker-compose up housing-register-api-test
+	docker compose up -d dynamodb-database
+	docker compose build housing-register-api-test && docker compose up housing-register-api-test
 
 .PHONY: lint
 lint:
@@ -30,4 +30,4 @@ lint:
 
 .PHONY: restart-db
 restart-db:
-	docker-compose up -d dynamodb-database
+	docker compose up -d dynamodb-database


### PR DESCRIPTION
## What
Hardens the housing API against unauthenticated application creation and auth endpoint abuse (following Probely/scanner findings), and simplifies deploy config by resolving central-account SSM parameters directly in Serverless. 

Turns out you could hit a POST on the applications route without auth. Resident application creation is unchanged — it goes through auth/generate, not POST /applications. This route is only staff creating a new application manually.

## Changes
### Staff auth on POST /api/v1/applications
- Adds StaffAuthValidator using the existing ITokenFactory / IHttpContextWrapper pattern (same as Novalet exports).
- Requires a valid staff JWT in the Authorization header with membership in admin, manager, or officer groups (read-only excluded).
- Returns 403 via UnauthorizedStaffException when validation fails.

### Auth email validation on generate/verify
- Adds AuthEmailValidator with length, character, and format checks (stricter than EmailAddressAttribute alone).
- Applied in CreateAuthUseCase and VerifyAuthUseCase; controllers return 400 on InvalidAuthEmailException.

### Serverless SSM refactor
- Replaces CircleCI-fetched deploy params with direct central-account SSM references in serverless.yml (aligned with the frontend pattern).
- Deploy now only passes --param="centralAccount=..."; removes the ~50-line SSM fetch step and awscli install from CircleCI.

### Staff group configuration
- Adds AUTHORISED_*_GROUP env vars from central SSM for staff JWT group validation.
- ApiOptions extended with GetStaffGroupsAllowedToCreateApplications().

### Other
- .gitguardian.yaml — ignores the shared E2E dummy staff JWT fixture.
- .editorconfig — scopes the private-field underscore rule to readonly fields so it no longer conflicts with the const PascalCase rule. Resulted in failure/fix cycle on locally or on pipeline.

## Test plan

- [ ] dotnet test passes locally / in CI
- [ ]  dotnet format --verify-no-changes passes
- [ ]  Deploy to development succeeds with central-parameter-store-context
- [ ]  Staff add-case still creates applications (valid hackneyToken + officer group)
- [ ]  POST /api/v1/applications without staff JWT returns 403
- [ ] POST /api/v1/auth/generate rejects malformed emails with 400
- [ ] Resident auth flow (generate → verify) still works for valid emails

## Notes
Companion BFF changes (staff gate on POST /api/applications) are in lbh-housing-register and should be deployed together for full coverage.