### PR TITLE
fix: await sqs

### DIFF
--- a/HousingRegisterApi.Tests/V1/UseCase/RecalculateBedroomsUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/RecalculateBedroomsUseCaseTests.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using FluentAssertions;
 using HousingRegisterApi.V1.Boundary.Response;
 using HousingRegisterApi.V1.Domain;
+using HousingRegisterApi.V1.Domain.Sns;
 using HousingRegisterApi.V1.Factories;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.Services;
@@ -12,6 +13,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace HousingRegisterApi.Tests.V1.UseCase
 {
@@ -33,6 +35,8 @@ namespace HousingRegisterApi.Tests.V1.UseCase
             _gatewayMock = new Mock<IApplicationApiGateway>();
             _notifyGatewayMock = new Mock<INotifyGateway>();
             _snsGatewayMock = new Mock<ISnsGateway>();
+            _snsGatewayMock.Setup(x => x.Publish(It.IsAny<ApplicationSns>()))
+                .Returns(Task.CompletedTask);
             _snsFactoryMock = new Mock<ISnsFactory>();
             _bedroomCalculatorServiceMock = new Mock<IBedroomCalculatorService>();
 

--- a/HousingRegisterApi/HousingRegisterApi.csproj
+++ b/HousingRegisterApi/HousingRegisterApi.csproj
@@ -42,7 +42,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.27" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
         <PackageReference Include="NEST" Version="7.10.0" />
-        <PackageReference Include="SSH.NET" Version="2020.0.2" />
+        <PackageReference Include="SSH.NET" Version="2026.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/HousingRegisterApi/V1/Gateways/ApplicationActivityGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/ApplicationActivityGateway.cs
@@ -62,7 +62,7 @@ namespace HousingRegisterApi.V1.Gateways
             if (token != null && activity.HasChanges())
             {
                 var applicationSnsMessage = _snsFactory.Update(application.Id, activity.OldData, activity.NewData, token);
-                _snsGateway.Publish(applicationSnsMessage);
+                _snsGateway.Publish(applicationSnsMessage).GetAwaiter().GetResult();
             }
             else if (token == null)
             {

--- a/HousingRegisterApi/V1/Gateways/ApplicationSnsGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/ApplicationSnsGateway.cs
@@ -1,11 +1,13 @@
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using HousingRegisterApi.V1.Domain.Sns;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 //using System.Text.Json;
 //using System.Text.Json.Serialization;
 
@@ -14,11 +16,15 @@ namespace HousingRegisterApi.V1.Gateways
     public class ApplicationSnsGateway : ISnsGateway
     {
         private readonly IAmazonSimpleNotificationService _amazonSimpleNotificationService;
+        private readonly ILogger<ApplicationSnsGateway> _logger;
         //private readonly JsonSerializerOptions _jsonOptions;
 
-        public ApplicationSnsGateway(IAmazonSimpleNotificationService amazonSimpleNotificationService)
+        public ApplicationSnsGateway(
+            IAmazonSimpleNotificationService amazonSimpleNotificationService,
+            ILogger<ApplicationSnsGateway> logger)
         {
             _amazonSimpleNotificationService = amazonSimpleNotificationService;
+            _logger = logger;
             //_jsonOptions = CreateJsonOptions();
         }
 
@@ -56,7 +62,18 @@ namespace HousingRegisterApi.V1.Gateways
                 MessageGroupId = "SomeGroupId"
             };
 
-            _amazonSimpleNotificationService.PublishAsync(request);
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                var response = _amazonSimpleNotificationService.PublishAsync(request).GetAwaiter().GetResult();
+                _logger.LogInformation("SNS ok {ApplicationId} {Id} {CorrelationId} {MessageId} {ElapsedMs}",
+                    applicationSns.EntityId, applicationSns.Id, applicationSns.CorrelationId, response.MessageId, sw.ElapsedMilliseconds);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SNS fail {ApplicationId} {Id} {CorrelationId}",
+                    applicationSns.EntityId, applicationSns.Id, applicationSns.CorrelationId);
+            }
         }
     }
 }

--- a/HousingRegisterApi/V1/Gateways/ApplicationSnsGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/ApplicationSnsGateway.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 //using System.Text.Json;
 //using System.Text.Json.Serialization;
 
@@ -44,7 +45,7 @@ namespace HousingRegisterApi.V1.Gateways
             NamingStrategy = new CamelCaseNamingStrategy()
         };
 
-        public void Publish(ApplicationSns applicationSns)
+        public async Task Publish(ApplicationSns applicationSns)
         {
             var options = new JsonSerializerSettings
             {
@@ -65,7 +66,7 @@ namespace HousingRegisterApi.V1.Gateways
             try
             {
                 var sw = Stopwatch.StartNew();
-                var response = _amazonSimpleNotificationService.PublishAsync(request).GetAwaiter().GetResult();
+                var response = await _amazonSimpleNotificationService.PublishAsync(request).ConfigureAwait(false);
                 _logger.LogInformation("SNS ok {ApplicationId} {Id} {CorrelationId} {MessageId} {ElapsedMs}",
                     applicationSns.EntityId, applicationSns.Id, applicationSns.CorrelationId, response.MessageId, sw.ElapsedMilliseconds);
             }

--- a/HousingRegisterApi/V1/Gateways/Interfaces/ISnsGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/Interfaces/ISnsGateway.cs
@@ -5,6 +5,6 @@ namespace HousingRegisterApi.V1.Gateways
 {
     public interface ISnsGateway
     {
-        void Publish(ApplicationSns applicationSns);
+        Task Publish(ApplicationSns applicationSns);
     }
 }

--- a/HousingRegisterApi/V1/UseCase/RecalculateBedroomsUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/RecalculateBedroomsUseCase.cs
@@ -96,7 +96,7 @@ namespace HousingRegisterApi.V1.UseCase
                         };
 
                         var applicationSnsMessage = _snsFactory.Update(application.Id, currentBedroomNeed, newBedroomNeed, token);
-                        _snsGateway.Publish(applicationSnsMessage);
+                        _snsGateway.Publish(applicationSnsMessage).GetAwaiter().GetResult();
                     }
 
                 }


### PR DESCRIPTION
What: 

* Await SQS publish as task
* Add logging to help debug SQS failures

Also
* Upgrades SSH.NET due to build failure for high severity vulnerability

`#7 15.52 /app/HousingRegisterApi/HousingRegisterApi.csproj : error NU1903: Warning As Error: Package 'SSH.NET' 2020.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-q939-rpr3-3284`

Package is used in the Novalet upload feature only so won't have an impact. 