### PR TITLE
Fix/reference number unique

### DIFF
--- a/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
+++ b/HousingRegisterApi.Tests/V1/E2ETests/CreateNewApplicationTest.cs
@@ -63,8 +63,24 @@ namespace HousingRegisterApi.Tests.V1.E2ETests
             apiEntity.Status.Should().Be(request.Status);
             apiEntity.SensitiveData.Should().Be(request.SensitiveData);
             apiEntity.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, 5000);
-            apiEntity.MainApplicant.Should().BeEquivalentTo(request.MainApplicant);
+            apiEntity.MainApplicant.Should().BeEquivalentTo(request.MainApplicant, options => options
+                .Excluding(x => x.ContactInformation.EmailAddress));
+            apiEntity.MainApplicant.ContactInformation.EmailAddress.Should().Be(
+                request.MainApplicant.ContactInformation.EmailAddress.Trim().ToLowerInvariant());
             apiEntity.OtherMembers.Should().BeEquivalentTo(request.OtherMembers);
+        }
+
+        [Test]
+        public async Task CreateNewApplicationReturnsConflictWhenEmailAlreadyExists()
+        {
+            var request = _applicationFixture.ConstructCreateApplicationRequest();
+            var json = JsonConvert.SerializeObject(request);
+
+            var firstResponse = await PostTestRequestAsync(json, includeStaffToken: true).ConfigureAwait(false);
+            firstResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+            var secondResponse = await PostTestRequestAsync(json, includeStaffToken: true).ConfigureAwait(false);
+            secondResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
         }
 
         [Test]

--- a/HousingRegisterApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/HousingRegisterApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -97,5 +97,17 @@ namespace HousingRegisterApi.Tests.V1.Gateways
             // Assert
             Assert.AreEqual(application.Reference, _hashHelper.Generate(emailAddress).Substring(0, 10), "Reference is incorrect");
         }
+
+        [Test]
+        public void CreateNewEntityHashesLowercasedEmail()
+        {
+            var createRequest = _fixture.Create<CreateApplicationRequest>();
+            createRequest.MainApplicant.ContactInformation.EmailAddress = "  Test.Email@TestDomain.com ";
+
+            var application = _classUnderTest.CreateNewApplication(createRequest);
+
+            Assert.AreEqual("test.email@testdomain.com", application.MainApplicant.ContactInformation.EmailAddress);
+            Assert.AreEqual(application.Reference, _hashHelper.Generate("test.email@testdomain.com").Substring(0, 10), "Reference is incorrect");
+        }
     }
 }

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateAuthUseCaseTests.cs
@@ -93,6 +93,39 @@ namespace HousingRegisterApi.Tests.V1.UseCase
         }
 
         [Test]
+        public void CreateVerifyCodeNormalizesEmailBeforeLookupAndCreate()
+        {
+            var application = _fixture.Create<Application>();
+
+            _mockApplicationGateway
+                .Setup(x => x.GetIncompleteApplication("resident@hackney.gov.uk"))
+                .Returns<Application>(null);
+
+            _mockApplicationGateway
+               .Setup(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()))
+               .Returns(application);
+
+            _mockApplicationGateway
+                .Setup(x => x.CreateVerifyCode(It.IsAny<Guid>(), It.IsAny<CreateAuthRequest>()))
+                .Returns(application);
+
+            var response = _classUnderTest.Execute(new CreateAuthRequest
+            {
+                Email = "  Resident@Hackney.gov.uk "
+            });
+
+            _mockApplicationGateway.Verify(x => x.GetIncompleteApplication("resident@hackney.gov.uk"), Times.Once);
+            _mockApplicationGateway.Verify(
+                x => x.CreateNewApplication(It.Is<CreateApplicationRequest>(
+                    r => r.MainApplicant.ContactInformation.EmailAddress == "resident@hackney.gov.uk")),
+                Times.Once);
+            _mockApplicationGateway.Verify(
+                x => x.CreateVerifyCode(application.Id, It.Is<CreateAuthRequest>(r => r.Email == "resident@hackney.gov.uk")),
+                Times.Once);
+            response.Should().BeOfType<CreateAuthResponse>();
+        }
+
+        [Test]
         public void CreateVerifyCodeThrowsWhenEmailIsInvalid()
         {
             Action act = () => _classUnderTest.Execute(new CreateAuthRequest

--- a/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
+++ b/HousingRegisterApi.Tests/V1/UseCase/CreateNewApplicationUseCaseTests.cs
@@ -72,7 +72,72 @@ namespace HousingRegisterApi.Tests.V1.UseCase
             var response = _classUnderTest.Execute(new CreateApplicationRequest());
 
             _mockGateway.Verify(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()));
+            _mockGateway.Verify(x => x.GetApplicationsByEmail(It.IsAny<string>()), Times.Never);
             response.Should().BeEquivalentTo(application.ToResponse());
+        }
+
+        [Test]
+        public void CreateNewApplicationLowercasesEmailAndCreatesWhenNoExistingApplication()
+        {
+            var application = _fixture.Create<Application>();
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns(new Token { Groups = new[] { "officer-group" } });
+            _mockGateway
+                .Setup(x => x.GetApplicationsByEmail("resident@hackney.gov.uk"))
+                .Returns(Array.Empty<Application>());
+            _mockGateway
+                .Setup(x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()))
+                .Returns(application);
+
+            var request = new CreateApplicationRequest
+            {
+                MainApplicant = new Applicant
+                {
+                    ContactInformation = new ContactInformation
+                    {
+                        EmailAddress = "  Resident@Hackney.gov.uk "
+                    }
+                }
+            };
+
+            var response = _classUnderTest.Execute(request);
+
+            request.MainApplicant.ContactInformation.EmailAddress.Should().Be("resident@hackney.gov.uk");
+            _mockGateway.Verify(x => x.GetApplicationsByEmail("resident@hackney.gov.uk"), Times.Once);
+            _mockGateway.Verify(x => x.CreateNewApplication(request), Times.Once);
+            response.Should().BeEquivalentTo(application.ToResponse());
+        }
+
+        [Test]
+        public void CreateNewApplicationThrowsWhenEmailAlreadyExists()
+        {
+            var existing = _fixture.Create<Application>();
+            _mockTokenFactory
+                .Setup(x => x.Create(It.IsAny<IHeaderDictionary>(), It.IsAny<string>()))
+                .Returns(new Token { Groups = new[] { "officer-group" } });
+            _mockGateway
+                .Setup(x => x.GetApplicationsByEmail("resident@hackney.gov.uk"))
+                .Returns(new[] { existing });
+
+            var request = new CreateApplicationRequest
+            {
+                MainApplicant = new Applicant
+                {
+                    ContactInformation = new ContactInformation
+                    {
+                        EmailAddress = "Resident@Hackney.gov.uk"
+                    }
+                }
+            };
+
+            Action act = () => _classUnderTest.Execute(request);
+
+            act.Should().Throw<DuplicateApplicationEmailException>()
+                .Which.ApplicationIds.Should().Contain(existing.Id);
+            _mockGateway.Verify(
+                x => x.CreateNewApplication(It.IsAny<CreateApplicationRequest>()),
+                Times.Never);
         }
 
         [Test]

--- a/HousingRegisterApi/V1/Boundary/Response/Exceptions/DuplicateApplicationEmailException.cs
+++ b/HousingRegisterApi/V1/Boundary/Response/Exceptions/DuplicateApplicationEmailException.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HousingRegisterApi.V1.Boundary.Response.Exceptions
+{
+    public class DuplicateApplicationEmailException : Exception
+    {
+        public IReadOnlyList<Guid> ApplicationIds { get; }
+
+        public DuplicateApplicationEmailException(IEnumerable<Guid> applicationIds)
+            : base($"An application already exists for this email. Case IDs: {string.Join(",", applicationIds)}")
+        {
+            ApplicationIds = applicationIds.ToList();
+        }
+    }
+}

--- a/HousingRegisterApi/V1/Controllers/ApplicationsApiController.cs
+++ b/HousingRegisterApi/V1/Controllers/ApplicationsApiController.cs
@@ -196,10 +196,12 @@ namespace HousingRegisterApi.V1.Controllers
         /// <response code="201">Returns the application created with its ID</response>
         /// <response code="400">Invalid fields in the post parameter.</response>
         /// <response code="403">Staff authorization required</response>
+        /// <response code="409">Application already exists for this email</response>
         /// <response code="500">Internal server error</response>
         [ProducesResponseType(typeof(ApplicationResponse), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         public IActionResult CreateNewApplication([FromBody] CreateApplicationRequest applicationRequest)
@@ -212,6 +214,10 @@ namespace HousingRegisterApi.V1.Controllers
             catch (UnauthorizedStaffException ex)
             {
                 return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+            }
+            catch (DuplicateApplicationEmailException ex)
+            {
+                return Conflict(new { message = ex.Message, applicationIds = ex.ApplicationIds });
             }
         }
 

--- a/HousingRegisterApi/V1/Gateways/DynamoDbGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/DynamoDbGateway.cs
@@ -355,18 +355,18 @@ namespace HousingRegisterApi.V1.Gateways
 
         public Application GetIncompleteApplication(string email)
         {
-            return GetApplicationsByEmail(email).FirstOrDefault();
+            var normalizedEmail = EmailNormalizer.Normalize(email);
+            if (normalizedEmail == null)
+            {
+                return null;
+            }
+
+            return GetApplicationsByEmail(normalizedEmail).FirstOrDefault();
         }
 
         public IEnumerable<Application> GetApplicationsByEmail(string email)
         {
-            var normalizedEmail = EmailNormalizer.Normalize(email);
-            if (normalizedEmail == null)
-            {
-                return Array.Empty<Application>();
-            }
-
-            string reference = _hashHelper.Generate(normalizedEmail).Substring(0, 10);
+            string reference = _hashHelper.Generate(email).Substring(0, 10);
 
             var table = _dynamoDbContext.GetTargetTable<ApplicationDbEntity>();
 

--- a/HousingRegisterApi/V1/Gateways/DynamoDbGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/DynamoDbGateway.cs
@@ -355,9 +355,19 @@ namespace HousingRegisterApi.V1.Gateways
 
         public Application GetIncompleteApplication(string email)
         {
-            string reference = _hashHelper.Generate(email).Substring(0, 10);
+            return GetApplicationsByEmail(email).FirstOrDefault();
+        }
 
-            var dbApplications = new List<ApplicationDbEntity>();
+        public IEnumerable<Application> GetApplicationsByEmail(string email)
+        {
+            var normalizedEmail = EmailNormalizer.Normalize(email);
+            if (normalizedEmail == null)
+            {
+                return Array.Empty<Application>();
+            }
+
+            string reference = _hashHelper.Generate(normalizedEmail).Substring(0, 10);
+
             var table = _dynamoDbContext.GetTargetTable<ApplicationDbEntity>();
 
             var queryConfig = new QueryOperationConfig
@@ -382,18 +392,18 @@ namespace HousingRegisterApi.V1.Gateways
             return _dynamoDbContext
                 .FromDocuments<ApplicationDbEntity>(resultsSet)
                 .Select(x => x.ToDomain())
-                .FirstOrDefault();
+                .ToList();
         }
 
         public Application CreateNewApplication(CreateApplicationRequest request)
         {
             var newApplicationGuid = Guid.NewGuid();
 
-            string emailAddress = request.MainApplicant?.ContactInformation?.EmailAddress;
+            string emailAddress = EmailNormalizer.Normalize(request.MainApplicant?.ContactInformation?.EmailAddress);
 
-            if (string.IsNullOrWhiteSpace(emailAddress))
+            if (request.MainApplicant?.ContactInformation != null)
             {
-                emailAddress = null;
+                request.MainApplicant.ContactInformation.EmailAddress = emailAddress;
             }
 
             var entity = new ApplicationDbEntity

--- a/HousingRegisterApi/V1/Gateways/Interfaces/IApplicationApiGateway.cs
+++ b/HousingRegisterApi/V1/Gateways/Interfaces/IApplicationApiGateway.cs
@@ -37,6 +37,8 @@ namespace HousingRegisterApi.V1.Gateways
 
         Application GetIncompleteApplication(string email);
 
+        IEnumerable<Application> GetApplicationsByEmail(string email);
+
         Application ImportApplication(ImportApplicationRequest request);
 
         Task<long> IssueNextBiddingNumber();

--- a/HousingRegisterApi/V1/Infrastructure/EmailNormalizer.cs
+++ b/HousingRegisterApi/V1/Infrastructure/EmailNormalizer.cs
@@ -1,0 +1,15 @@
+namespace HousingRegisterApi.V1.Infrastructure
+{
+    public static class EmailNormalizer
+    {
+        public static string Normalize(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                return null;
+            }
+
+            return email.Trim().ToLowerInvariant();
+        }
+    }
+}

--- a/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/CreateAuthUseCase.cs
@@ -37,7 +37,7 @@ namespace HousingRegisterApi.V1.UseCase
                 throw new InvalidAuthEmailException();
             }
 
-            var email = request.Email.Trim();
+            var email = EmailNormalizer.Normalize(request.Email);
 
             if (BlockedAuthEmailMatcher.IsBlocked(email, _apiOptions.BlockedAuthEmails))
             {

--- a/HousingRegisterApi/V1/UseCase/CreateNewApplicationUseCase.cs
+++ b/HousingRegisterApi/V1/UseCase/CreateNewApplicationUseCase.cs
@@ -3,12 +3,14 @@ using Hackney.Core.JWT;
 using HousingRegisterApi.V1;
 using HousingRegisterApi.V1.Boundary.Request;
 using HousingRegisterApi.V1.Boundary.Response;
+using HousingRegisterApi.V1.Boundary.Response.Exceptions;
 using HousingRegisterApi.V1.Domain;
 using HousingRegisterApi.V1.Factories;
 using HousingRegisterApi.V1.Gateways;
 using HousingRegisterApi.V1.Infrastructure;
 using HousingRegisterApi.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Http;
+using System.Linq;
 
 namespace HousingRegisterApi.V1.UseCase
 {
@@ -44,6 +46,21 @@ namespace HousingRegisterApi.V1.UseCase
                 _contextWrapper,
                 _tokenFactory,
                 _apiOptions);
+
+            if (request.MainApplicant?.ContactInformation != null)
+            {
+                var email = EmailNormalizer.Normalize(request.MainApplicant.ContactInformation.EmailAddress);
+                request.MainApplicant.ContactInformation.EmailAddress = email;
+
+                if (email != null)
+                {
+                    var existingApplications = _gateway.GetApplicationsByEmail(email).ToList();
+                    if (existingApplications.Any())
+                    {
+                        throw new DuplicateApplicationEmailException(existingApplications.Select(x => x.Id));
+                    }
+                }
+            }
 
             Application application = _gateway.CreateNewApplication(request);
 


### PR DESCRIPTION
## What

When a staff member creates an application triggering CreateNewApplicationUseCase, no validation or checks on existance are performed on the email address. The email address (if supplied) forms the base of the reference number, so if the email address is the same the hash will be the same. 

It's not a requirment that the email is provided in this workflow, and leaving it blank will create a unique reference number. We could force a unique number always on this path but their are cases where a legitimate email address might be used, and that hash is used if a resident logs into see their application.

So this seemed like the most sensible solution - check if the email exists and 409 if it does. We also add validation to normalise email address - both on staff and resident paths. 

** Should the check be on both normalised and the inputed email? ** 


## Also
- I'll handle the 409 on the FE,
- This check will pick up only existing hashes that are normalised (i.e. Sam.Drumm@cool.com won't be matched)
- I've asked the team if adding their own staff email to an application represents a legitimate workflow, if so we'll have to handle that.
